### PR TITLE
Add remotes section to description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,5 +32,7 @@ Suggests:
     rmarkdown,
     withr,
     testthat (>= 2.1.0)
+Remotes:
+    andrjohns/StanEstimators@main
 Imports: ellipse, rstan, R2admb, ggplot2, rlang
 VignetteBuilder: knitr


### PR DESCRIPTION
I think the FIMS case studies codespace is having trouble building because it can't find StanEstimators, which is needed for the adnuts sparse-M branch - adding the Remotes section of the desciption should help install it automatically when a user installs adnuts (I tried locally and this worked for me).

See this example: https://github.com/nmfs-ost/SSMSE/blob/main/DESCRIPTION